### PR TITLE
Add a Get Mapping service

### DIFF
--- a/client.go
+++ b/client.go
@@ -171,6 +171,12 @@ func (c *Client) Ping() *PingService {
 	return NewPingService(c)
 }
 
+// GetMapping returns a service to get the mapping of an index.
+func (c *Client) GetMapping() *GetMappingService {
+	builder := NewGetMappingService(c)
+	return builder
+}
+
 // CreateIndex returns a service to create a new index.
 func (c *Client) CreateIndex(name string) *CreateIndexService {
 	builder := NewCreateIndexService(c)

--- a/get_mapping.go
+++ b/get_mapping.go
@@ -1,0 +1,85 @@
+package elastic
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/olivere/elastic/uritemplates"
+)
+
+type GetMappingService struct {
+	client *Client
+	index  string
+	pretty bool
+	debug  bool
+}
+
+func NewGetMappingService(client *Client) *GetMappingService {
+	builder := &GetMappingService{
+		client: client,
+	}
+	return builder
+}
+
+func (b *GetMappingService) Get(index string) *GetMappingService {
+	b.index = index
+	return b
+}
+
+func (b *GetMappingService) Pretty(pretty bool) *GetMappingService {
+	b.pretty = pretty
+	return b
+}
+
+func (b *GetMappingService) Debug(debug bool) *GetMappingService {
+	b.debug = debug
+	return b
+}
+
+func (b *GetMappingService) Do() (string, error) {
+	// Build url
+	urls, err := uritemplates.Expand("/{index}/_mapping", map[string]string{
+		"index": b.index,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// Parameters
+	params := make(url.Values)
+	if b.pretty {
+		params.Set("pretty", fmt.Sprintf("%v", b.pretty))
+	}
+	if len(params) > 0 {
+		urls += "?" + params.Encode()
+	}
+
+	// Set up a new request
+	req, err := b.client.NewRequest("GET", urls)
+	if err != nil {
+		return "", err
+	}
+
+	if b.debug {
+		b.client.dumpRequest((*http.Request)(req))
+	}
+
+	// Get response
+	res, err := b.client.c.Do((*http.Request)(req))
+	if err != nil {
+		return "", err
+	}
+	if err := checkResponse(res); err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+
+	contents, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(contents), nil
+}

--- a/get_mapping_test.go
+++ b/get_mapping_test.go
@@ -1,0 +1,52 @@
+package elastic
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGetMapping(t *testing.T) {
+	client := setupTestClient(t)
+
+	// create an empty index
+	createIndex, err := client.CreateIndex(testIndexName).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if createIndex == nil {
+		t.Errorf("expected result to be != nil; got: %v", createIndex)
+	}
+
+	// get the empty index mapping
+	mapping, err := client.GetMapping().Get(testIndexName).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectEmptyMap := fmt.Sprintf(`{"%s":{"mappings":{}}}`, testIndexName)
+	if mapping != expectEmptyMap {
+		t.Fatalf("Expected mapping = %s; got: %s", expectEmptyMap, mapping)
+	}
+
+	// create an index with a mapping
+	newMap := `{"mappings":{"tweet":{"properties":{"location":{"type":"geo_point"},"tags":{"type":"string"}}}}}`
+	expectedFullMap := fmt.Sprintf(`{"%s":%s}`, testIndexName2, newMap)
+
+	createIndex, err = client.CreateIndex(testIndexName2).Body(newMap).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if createIndex == nil {
+		t.Errorf("expected result to be != nil; got: %v", createIndex)
+	}
+
+	// get the index mapping
+	mapping, err = client.GetMapping().Get(testIndexName2).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if mapping != expectedFullMap {
+		t.Fatalf("Expected mapping = %s; got: %s", expectedFullMap, mapping)
+	}
+}


### PR DESCRIPTION
Add ability to get mapping from `elasticsearch` using `elastic`.

Usage:
```go
client, err := elastic.NewClient(http.DefaultClient)
if err != nil {
	panic(err)
}

mapping, err := client.GetMapping().Get(index).
	Debug(true).  // print request and response to stdout
	Pretty(true). // pretty print request and response JSON
	Do()
fmt.Printf(os.Stdout, "Got mapping: %s", mapping)
```

Right now the mapping is just returned as a `string` - no JSON unmarshalling.